### PR TITLE
Migrate dependencies from git submodules to build.zig.zon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .zig-cache/
 zig-out/
+zig-pkg/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libs/clap"]
-	path = libs/clap
-	url = git@github.com:Hejsil/zig-clap.git

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Requirements: `zig` (master/0.16.0-dev recommended).
 
 ```bash
 # 1. Clone the repo
-git clone --recursive https://github.com/here-Leslie-Lau/zlist.git
+git clone git@github.com:here-Leslie-Lau/zlist.git
 cd zlist
 
 # 2. Build in release mode [ReleaseFast, ReleaseSafe, ReleaseSmall]
@@ -159,6 +159,7 @@ zl -lg
 *   [x] Smart dynamic grid layout
 *   [x] Summary report (`-R`)
 *   [x] Git status integration (`-g`)
+*   [ ] Lib API for embedding in other Zig projects
 *   [ ] Multi-threading for faster `stat` calls
 *   [ ] Custom color/icon configurations (Maybe, if you need it)
 

--- a/build.zig
+++ b/build.zig
@@ -22,14 +22,12 @@ pub fn build(b: *std.Build) void {
         });
 
         // add clap as a dependency
-        const clap = b.addModule(
-            "clap",
-            .{
-                .root_source_file = b.path("libs/clap/clap.zig"),
-                .link_libc = true,
-            },
-        );
-        exe.root_module.addImport("clap", clap);
+        const clap = b.dependency("clap", .{
+            .target = target,
+            .optimize = optimize,
+        });
+
+        exe.root_module.addImport("clap", clap.module("clap"));
 
         b.installArtifact(exe);
     }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .zlist,
+    .version = "0.16.0-dev.3142+5ccfeb926",
+    .dependencies = .{
+        .clap = .{
+            .url = "git+https://github.com/Hejsil/zig-clap#fc1e5cc3f6d9d3001112385ee6256d694e959d2f",
+            .hash = "clap-0.11.0-oBajB7foAQC3Iyn4IVCkUdYaOVVng5IZkSncySTjNig1",
+        },
+    },
+    .paths = .{""},
+    .fingerprint = 0x10cc28778dc796fb,
+}


### PR DESCRIPTION
This PR moves dependencies from git submodules to Zig's native dependency management using `build.zig.zon`.

Dependencies were previously vendored under libs/ via submodules. With this change, they're now managed through build.zig.zon and the dependency API, which keeps the repo cleaner and makes updates easier.

This also lays some groundwork for turning zlist into a library later on.

Let me know if anything looks off.