### PR TITLE
fix: memory leak in username/groupname/git hashmap cleanup

### DIFF
--- a/src/file.zig
+++ b/src/file.zig
@@ -83,6 +83,7 @@ pub const File = struct {
         entry: *const std.Io.Dir.Entry,
         dir: *const std.Io.Dir,
         opt: opts.FileOptions,
+        allocator: std.mem.Allocator,
         username_inventory: *std.AutoHashMap(std.c.uid_t, []const u8),
         groupname_inventory: *std.AutoHashMap(std.c.gid_t, []const u8),
     ) !?Self {
@@ -137,8 +138,8 @@ pub const File = struct {
             }
 
             if (opt.load_owner and builtin.os.tag != .windows) {
-                file.username = file.getName(.User, username_inventory, groupname_inventory) orelse "UNKNOWN";
-                file.groupname = file.getName(.Group, username_inventory, groupname_inventory) orelse "UNKNOWN";
+                file.username = file.getName(.User, allocator, username_inventory, groupname_inventory) orelse "UNKNOWN";
+                file.groupname = file.getName(.Group, allocator, username_inventory, groupname_inventory) orelse "UNKNOWN";
             }
         }
 
@@ -421,6 +422,7 @@ pub const File = struct {
     pub inline fn getName(
         self: Self,
         name: NameByID,
+        allocator: std.mem.Allocator,
         ui: *std.AutoHashMap(std.c.uid_t, []const u8),
         gi: *std.AutoHashMap(std.c.gid_t, []const u8),
     ) ?[]const u8 {
@@ -442,9 +444,10 @@ pub const File = struct {
                 }
 
                 const str = std.mem.span(passwd.?.*.name) orelse return null;
-                ui.put(uid, str) catch return null;
+                const owned_str = allocator.dupe(u8, str) catch return null;
+                ui.put(uid, owned_str) catch return null;
 
-                return str;
+                return owned_str;
             },
             .Group => {
                 const gid = self.stat_t.?.gid;
@@ -458,9 +461,10 @@ pub const File = struct {
                 }
 
                 const str = std.mem.span(group.?.*.name) orelse return null;
-                gi.put(gid, str) catch return null;
+                const owned_str = allocator.dupe(u8, str) catch return null;
+                gi.put(gid, owned_str) catch return null;
 
-                return str;
+                return owned_str;
             },
         }
     }

--- a/src/files.zig
+++ b/src/files.zig
@@ -114,6 +114,7 @@ pub const Files = struct {
                     .size_range = opt.size_range,
                     .changed_within_now = changed_within_now,
                 },
+                allocator,
                 &username_inventory,
                 &groupname_inventory,
             )) orelse continue;

--- a/src/files.zig
+++ b/src/files.zig
@@ -55,10 +55,13 @@ pub const Files = struct {
     /// since getting username from uid is a costly operation, we can cache it to improve performance.
     username_inventory: std.AutoHashMap(std.c.uid_t, []const u8),
     groupname_inventory: std.AutoHashMap(std.c.gid_t, []const u8),
+    username_inventory_initialized: bool = false,
+    groupname_inventory_initialized: bool = false,
 
     loaded_git: bool = false,
     /// for caching git status, key is filename, value is git status.
     git_inventory: std.StringHashMap(git.GitStatus),
+    git_inventory_initialized: bool = false,
 
     /// init a Files from a directory
     pub fn init(
@@ -89,9 +92,13 @@ pub const Files = struct {
         // initialize inventory if show_detail is true, otherwise leave them as undefined to save memory.
         var username_inventory: std.AutoHashMap(std.c.uid_t, []const u8) = undefined;
         var groupname_inventory: std.AutoHashMap(std.c.gid_t, []const u8) = undefined;
+        var username_inventory_initialized = false;
+        var groupname_inventory_initialized = false;
         if (opt.show_detail) {
             username_inventory = std.AutoHashMap(std.c.uid_t, []const u8).init(allocator);
             groupname_inventory = std.AutoHashMap(std.c.gid_t, []const u8).init(allocator);
+            username_inventory_initialized = true;
+            groupname_inventory_initialized = true;
         }
 
         var it = dir.iterate();
@@ -197,8 +204,11 @@ pub const Files = struct {
             .opt = opt,
             .username_inventory = username_inventory,
             .groupname_inventory = groupname_inventory,
+            .username_inventory_initialized = username_inventory_initialized,
+            .groupname_inventory_initialized = groupname_inventory_initialized,
             .loaded_git = loaded_git,
             .git_inventory = git_inventory,
+            .git_inventory_initialized = loaded_git,
         };
     }
 
@@ -238,9 +248,13 @@ pub const Files = struct {
 
         var username_inventory: std.AutoHashMap(std.c.uid_t, []const u8) = undefined;
         var groupname_inventory: std.AutoHashMap(std.c.gid_t, []const u8) = undefined;
+        var username_inventory_initialized = false;
+        var groupname_inventory_initialized = false;
         if (opt.show_detail) {
             username_inventory = std.AutoHashMap(std.c.uid_t, []const u8).init(allocator);
             groupname_inventory = std.AutoHashMap(std.c.gid_t, []const u8).init(allocator);
+            username_inventory_initialized = true;
+            groupname_inventory_initialized = true;
         }
 
         if (try file.File.init(
@@ -261,6 +275,7 @@ pub const Files = struct {
                 .size_range = opt.size_range,
                 .changed_within_now = changed_within_now,
             },
+            allocator,
             &username_inventory,
             &groupname_inventory,
         )) |single_file| {
@@ -299,8 +314,11 @@ pub const Files = struct {
             .opt = opt,
             .username_inventory = username_inventory,
             .groupname_inventory = groupname_inventory,
+            .username_inventory_initialized = username_inventory_initialized,
+            .groupname_inventory_initialized = groupname_inventory_initialized,
             .loaded_git = loaded_git,
             .git_inventory = git_inventory,
+            .git_inventory_initialized = loaded_git,
         };
     }
 
@@ -314,6 +332,30 @@ pub const Files = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        if (self.username_inventory_initialized) {
+            var username_it = self.username_inventory.keyIterator();
+            while (username_it.next()) |_| {
+                self.allocator.free(username_it.value().*);
+            }
+            self.username_inventory.deinit();
+        }
+
+        if (self.groupname_inventory_initialized) {
+            var groupname_it = self.groupname_inventory.keyIterator();
+            while (groupname_it.next()) |_| {
+                self.allocator.free(groupname_it.value().*);
+            }
+            self.groupname_inventory.deinit();
+        }
+
+        if (self.git_inventory_initialized) {
+            var git_it = self.git_inventory.keyIterator();
+            while (git_it.next()) |_| {
+                self.allocator.free(git_it.value().*);
+            }
+            self.git_inventory.deinit();
+        }
+
         self.items.deinit(self.allocator);
     }
 


### PR DESCRIPTION
## Summary
- Fix memory leak when cleaning up cached username/groupname/git strings
- The hashmaps store allocated strings but weren't being freed on deinit
- Add initialized flags to track whether hashmaps were actually initialized before attempting to deinitialize them (since they may be undefined when show_detail/show_git is false)

## Changes
- Add `username_inventory_initialized`, `groupname_inventory_initialized`, and `git_inventory_initialized` fields to track initialization state
- In `deinit()`, iterate through hash maps and free the allocated string values before calling deinit()
- This ensures the memory is properly returned to the allocator