### PR TITLE
feat: Sorting rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ $ zl --help
         --du
             Show recursive directory size in long view and size sort. This is the sum of file sizes, not the same as `du` disk usage.
 
+        --dir-first
+            List directories before files
+
+        --dir-last
+            List directories after files
+
     -s, --sort <SORTTYPE>
             Sort results. Default: name. OPTIONS: name, length, dir_first, mtime, size.
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,8 @@ $ zl --help
         --du
             Show recursive directory size in long view and size sort. This is the sum of file sizes, not the same as `du` disk usage.
 
-        --dir-first
-            List directories before files
-
-        --dir-last
-            List directories after files
+        --dir-grouping <DIRGROUPING>
+            Group directories before or after files. Default: none. OPTIONS: none, before, after.
 
     -s, --sort <SORTTYPE>
             Sort results. Default: name. OPTIONS: name, length, dir_first, mtime, size.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ $ zl --help
     -s, --sort <SORTTYPE>
             Sort results. Default: name. OPTIONS: name, length, dir_first, mtime, size.
 
+        --reverse
+            Reverse sort.
+
         --size <str>...
             Filter files by size range (e.g. --size gt:10K --size lte:2M).
 

--- a/docs/using-as-a-module.md
+++ b/docs/using-as-a-module.md
@@ -63,6 +63,7 @@ Useful options:
 | :--- | :--- |
 | `show_hidden` | Include names starting with `.`. |
 | `show_detail` | Load extra metadata such as size, permissions, owner, and symlink target. |
+| `dir_grouping` | Group directories `.none`, `.before`, `.after` |
 | `sort_type` | Sort by `.name`, `.length`, `.dir_first`, `.mtime`, or `.size`. |
 | `only_dir` | Keep only directories. |
 | `only_file` | Keep only files. |

--- a/docs/using-as-a-module.md
+++ b/docs/using-as-a-module.md
@@ -106,6 +106,7 @@ Available types:
 - `zlist.Files`
 - `zlist.FilesOptions`
 - `zlist.FileOptions`
+- `zlist.DirGrouping`
 - `zlist.SortType`
 - `zlist.SizeRange`
 - `zlist.GitStatus`

--- a/docs/using-as-a-module.md
+++ b/docs/using-as-a-module.md
@@ -65,6 +65,7 @@ Useful options:
 | `show_detail` | Load extra metadata such as size, permissions, owner, and symlink target. |
 | `dir_grouping` | Group directories `.none`, `.before`, `.after` |
 | `sort_type` | Sort by `.name`, `.length`, `.dir_first`, `.mtime`, or `.size`. |
+| `reverse` | Reverse sort. |
 | `only_dir` | Keep only directories. |
 | `only_file` | Keep only files. |
 | `exts` | Hide files with matching extensions. |

--- a/src/cli_args.zig
+++ b/src/cli_args.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const zlist = @import("zlist");
+
 const render = @import("render.zig");
 
 pub const CliConfig = struct {
@@ -49,6 +50,10 @@ pub inline fn parseCliConfig(allocator: std.mem.Allocator, res: anytype) !CliCon
 
     if (res.args.sort) |sort| {
         opt.sort_type = sort;
+    }
+
+    if (res.args.reverse != 0) {
+        opt.reverse = true;
     }
 
     if (res.args.pure != 0) {

--- a/src/cli_args.zig
+++ b/src/cli_args.zig
@@ -43,6 +43,10 @@ pub inline fn parseCliConfig(allocator: std.mem.Allocator, res: anytype) !CliCon
         opt.recursive_dir_size = true;
     }
 
+    if (res.args.@"dir-grouping") |dir_grouping| {
+        opt.dir_grouping = dir_grouping;
+    }
+
     if (res.args.sort) |sort| {
         opt.sort_type = sort;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,6 +22,7 @@ const params_desc: []const u8 = blk: {
     \\    --du                         Show recursive directory size in long view and size sort. This is the sum of file sizes, not the same as `du` disk usage.
     \\    --dir-grouping <DIRGROUPING> Group directories before or after files. Default: none. OPTIONS: none, before, after.
     \\-s, --sort <SORTTYPE>            Sort results. Default: name. OPTIONS: name, length, dir_first, mtime, size.
+    \\    --reverse                    Reverse sort
     \\    --size <str>...              Filter files by size range (e.g. --size gt:10K --size lte:2M).
     \\    --changed-within <str>       Only show entries changed within a time range (e.g. --changed-within 7d).
     \\-r, --recursive                  Recurse into subdirectories. Same as -L 0.

--- a/src/main.zig
+++ b/src/main.zig
@@ -20,15 +20,15 @@ const params_desc: []const u8 = blk: {
     \\    --no-icon                    Hide icon from the long view.
     \\-a, --a                          Include hidden entries.
     \\    --du                         Show recursive directory size in long view and size sort. This is the sum of file sizes, not the same as `du` disk usage.
-    \\    --dir-grouping <DIRGROUPING> Group directories before or after files. Default: none. OPTIONS: none, before, after.
+    \\-G, --dir-grouping <DIRGROUPING> Group directories before or after files. Default: none. OPTIONS: none, before, after.
     \\-s, --sort <SORTTYPE>            Sort results. Default: name. OPTIONS: name, length, dir_first, mtime, size.
-    \\    --reverse                    Reverse sort
+    \\-R, --reverse                    Reverse sort
     \\    --size <str>...              Filter files by size range (e.g. --size gt:10K --size lte:2M).
     \\    --changed-within <str>       Only show entries changed within a time range (e.g. --changed-within 7d).
     \\-r, --recursive                  Recurse into subdirectories. Same as -L 0.
     \\-L, --level <INT>                Limit recursion depth. 0 means no limit.
     \\-p, --pure                       Show names only, without colors or icons.
-    \\-R, --report                     Show a short summary of files and folders.
+    \\    --report                     Show a short summary of files and folders.
     \\-d, --dir                        Only show directories. If used with -D, both are ignored.
     \\-D, --no_dir                     Only show files. If used with -d, both are ignored.
     \\-g, --git                        Show git status in long view.

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,28 +10,29 @@ var threaded: std.Io.Threaded = undefined;
 
 const params_desc: []const u8 = blk: {
     break :blk
-    \\-h, --help                 Usage: zl [OPTIONS] [PATH]...
-    \\-l, --long                 Show the long view.
-    \\    --no-permissions       Hide permissions from the long view.
-    \\    --no-user              Hide user from the long view.
-    \\    --no-group             Hide group from the long view.
-    \\    --no-size              Hide size from the long view.
-    \\    --no-time              Hide time from the long view.
-    \\    --no-icon              Hide icon from the long view.
-    \\-a, --a                    Include hidden entries.
-    \\    --du                   Show recursive directory size in long view and size sort. This is the sum of file sizes, not the same as `du` disk usage.
-    \\-s, --sort <SORTTYPE>      Sort results. Default: name. OPTIONS: name, length, dir_first, mtime, size.
-    \\    --size <str>...        Filter files by size range (e.g. --size gt:10K --size lte:2M).
-    \\    --changed-within <str> Only show entries changed within a time range (e.g. --changed-within 7d).
-    \\-r, --recursive            Recurse into subdirectories. Same as -L 0.
-    \\-L, --level <INT>          Limit recursion depth. 0 means no limit.
-    \\-p, --pure                 Show names only, without colors or icons.
-    \\-R, --report               Show a short summary of files and folders.
-    \\-d, --dir                  Only show directories. If used with -D, both are ignored.
-    \\-D, --no_dir               Only show files. If used with -d, both are ignored.
-    \\-g, --git                  Show git status in long view.
-    \\-e, --ext <str>...         Filter by extension (e.g. --ext zig,md,ts).
-    \\-m, --match <str>...       Filter names by substring (e.g. --match main,readme).
+    \\-h, --help                       Usage: zl [OPTIONS] [PATH]...
+    \\-l, --long                       Show the long view.
+    \\    --no-permissions             Hide permissions from the long view.
+    \\    --no-user                    Hide user from the long view.
+    \\    --no-group                   Hide group from the long view.
+    \\    --no-size                    Hide size from the long view.
+    \\    --no-time                    Hide time from the long view.
+    \\    --no-icon                    Hide icon from the long view.
+    \\-a, --a                          Include hidden entries.
+    \\    --du                         Show recursive directory size in long view and size sort. This is the sum of file sizes, not the same as `du` disk usage.
+    \\    --dir-grouping <DIRGROUPING> Group directories before or after files. Default: none. OPTIONS: none, before, after.
+    \\-s, --sort <SORTTYPE>            Sort results. Default: name. OPTIONS: name, length, dir_first, mtime, size.
+    \\    --size <str>...              Filter files by size range (e.g. --size gt:10K --size lte:2M).
+    \\    --changed-within <str>       Only show entries changed within a time range (e.g. --changed-within 7d).
+    \\-r, --recursive                  Recurse into subdirectories. Same as -L 0.
+    \\-L, --level <INT>                Limit recursion depth. 0 means no limit.
+    \\-p, --pure                       Show names only, without colors or icons.
+    \\-R, --report                     Show a short summary of files and folders.
+    \\-d, --dir                        Only show directories. If used with -D, both are ignored.
+    \\-D, --no_dir                     Only show files. If used with -d, both are ignored.
+    \\-g, --git                        Show git status in long view.
+    \\-e, --ext <str>...               Filter by extension (e.g. --ext zig,md,ts).
+    \\-m, --match <str>...             Filter names by substring (e.g. --match main,readme).
     \\<str>...
     \\
     ;
@@ -52,6 +53,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     // parsers
     const parsers = comptime .{
         .str = clap.parsers.string,
+        .DIRGROUPING = clap.parsers.enumeration(zlist.DirGrouping),
         .SORTTYPE = clap.parsers.enumeration(zlist.SortType),
         .INT = clap.parsers.int(i8, 10),
     };

--- a/src/zlist.zig
+++ b/src/zlist.zig
@@ -12,6 +12,7 @@ pub const Files = @import("zlist/files.zig").Files;
 pub const FilesOptions = opts.FilesOptions;
 pub const FileOptions = opts.FileOptions;
 
+pub const DirGrouping = opts.DirGrouping;
 pub const SortType = opts.SortType;
 pub const SizeRange = opts.SizeRange;
 pub const GitStatus = @import("zlist/git.zig").GitStatus;

--- a/src/zlist/files.zig
+++ b/src/zlist/files.zig
@@ -137,7 +137,7 @@ pub const Files = struct {
             loaded_git = true;
         }
 
-        sort(files.items, opt.dir_grouping, opt.sort_type);
+        sort(files.items, opt.dir_grouping, opt.sort_type, opt.reverse);
 
         return .{
             .max_display_len = max_len,
@@ -366,6 +366,7 @@ pub const Files = struct {
     const SortCtx = struct {
         sort_type: opts.SortType,
         dir_grouping: opts.DirGrouping,
+        reverse: bool,
 
         fn lessThan(ctx: SortCtx, a: file.File, b: file.File) bool {
             if (ctx.dir_grouping != .none) {
@@ -374,22 +375,25 @@ pub const Files = struct {
                 if (a_dir != b_dir) return a_dir == (ctx.dir_grouping == .before);
             }
 
-            return switch (ctx.sort_type) {
+            const res = switch (ctx.sort_type) {
                 .length => file.File.nameLenLessThan({}, a, b),
                 .mtime => file.File.mtimeMoreThan({}, a, b),
                 .size => file.File.sizeMoreThan({}, a, b),
                 else => file.File.nameLessThan({}, a, b),
             };
+
+            return if (ctx.reverse) !res else res;
         }
     };
 
-    fn sort(items: []file.File, dir_grouping: opts.DirGrouping, sort_type: opts.SortType) void {
+    fn sort(items: []file.File, dir_grouping: opts.DirGrouping, sort_type: opts.SortType, reverse: bool) void {
         mem.sortUnstable(
             file.File,
             items,
             SortCtx{
                 .dir_grouping = dir_grouping,
                 .sort_type = sort_type,
+                .reverse = reverse,
             },
             SortCtx.lessThan,
         );

--- a/src/zlist/files.zig
+++ b/src/zlist/files.zig
@@ -3,8 +3,8 @@ const mem = std.mem;
 const testing = std.testing;
 
 const file = @import("file.zig");
-const opts = @import("opts.zig");
 const git = @import("git.zig");
+const opts = @import("opts.zig");
 
 pub const Files = struct {
     const Self = @This();
@@ -137,7 +137,7 @@ pub const Files = struct {
             loaded_git = true;
         }
 
-        sort(files.items, opt.sort_type);
+        sort(files.items, opt.dir_grouping, opt.sort_type);
 
         return .{
             .max_display_len = max_len,
@@ -363,29 +363,36 @@ pub const Files = struct {
         self.total_files += child.total_files;
     }
 
-    fn sort(items: []file.File, sort_type: opts.SortType) void {
-        switch (sort_type) {
-            .length => {
-                // sort by name length
-                mem.sortUnstable(file.File, items, {}, file.File.nameLenLessThan);
-            },
-            .dir_first => {
-                // sort by directory first
-                mem.sortUnstable(file.File, items, {}, file.File.dirMoreThan);
-            },
-            .mtime => {
-                // sort by modification time desc
-                mem.sortUnstable(file.File, items, {}, file.File.mtimeMoreThan);
-            },
-            .size => {
-                // sort by file size desc
-                mem.sortUnstable(file.File, items, {}, file.File.sizeMoreThan);
-            },
-            else => {
-                // sort by name ascending
-                mem.sortUnstable(file.File, items, {}, file.File.nameLessThan);
-            },
+    const SortCtx = struct {
+        sort_type: opts.SortType,
+        dir_grouping: opts.DirGrouping,
+
+        fn lessThan(ctx: SortCtx, a: file.File, b: file.File) bool {
+            if (ctx.dir_grouping != .none) {
+                const a_dir = a.is_dir;
+                const b_dir = b.is_dir;
+                if (a_dir != b_dir) return a_dir == (ctx.dir_grouping == .before);
+            }
+
+            return switch (ctx.sort_type) {
+                .length => file.File.nameLenLessThan({}, a, b),
+                .mtime => file.File.mtimeMoreThan({}, a, b),
+                .size => file.File.sizeMoreThan({}, a, b),
+                else => file.File.nameLessThan({}, a, b),
+            };
         }
+    };
+
+    fn sort(items: []file.File, dir_grouping: opts.DirGrouping, sort_type: opts.SortType) void {
+        mem.sortUnstable(
+            file.File,
+            items,
+            SortCtx{
+                .dir_grouping = dir_grouping,
+                .sort_type = sort_type,
+            },
+            SortCtx.lessThan,
+        );
     }
 
     /// recursively calculate directory size by summing up sizes of all descendant files.

--- a/src/zlist/opts.zig
+++ b/src/zlist/opts.zig
@@ -1,12 +1,19 @@
 const std = @import("std");
 
+pub const DirGrouping = enum {
+    /// no grouping
+    none,
+    /// group before files
+    before,
+    /// group after files
+    after,
+};
+
 pub const SortType = enum {
     /// sort by name(asc)
     name,
     /// sort by name length(asc). Default
     length,
-    /// sort by group directories first
-    dir_first,
     /// sort by modification time(desc)
     mtime,
     /// sort by file size(desc)
@@ -27,6 +34,8 @@ pub const FilesOptions = struct {
     show_hidden: bool = false,
     /// report mode, shows brief report about number of files and folders shown
     report: bool = false,
+    /// dir grouping
+    dir_grouping: DirGrouping = .none,
     /// sort type
     sort_type: SortType = .name,
     /// only show directories, not files

--- a/src/zlist/opts.zig
+++ b/src/zlist/opts.zig
@@ -38,6 +38,8 @@ pub const FilesOptions = struct {
     dir_grouping: DirGrouping = .none,
     /// sort type
     sort_type: SortType = .name,
+    /// reverse sort
+    reverse: bool = false,
     /// only show directories, not files
     only_dir: bool = false,
     /// only show files, not directories


### PR DESCRIPTION
This PR reworks how sorting works by extracting dir-first into a separate flag, `dir-grouping`, to allow for sorting combinations.
For now, it only supports the long flag, but I could make it work with a short one too, I just wasn't sure which letter to pick.
Maybe `G` since `d`, `D` and `g` are used by `--dir`, `--no-dir` and `--git`?

<img width="1689" height="1416" alt="image" src="https://github.com/user-attachments/assets/3d2d0958-e0f5-4e45-bd1f-7a683680634e" />


I could also look into implementing `--reverse`, which would reverse the sort(useful when sorting by size for example), whilst still respecting `dir-grouping`.

I would like to mention that I did use AI, specifically Claude, for help with the sorting function.
The reason is that I wanted to keep it as efficient as possible, and I genuinely don't have enough experience in the sorting field to do it on my own.
I understand if this is a deal breaker.

closes #70 