### PR TITLE
feat: Header and dynamic col size

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ $ zl --help
     -l, --long
             Show the long view.
 
+        --header
+            Show header in the long view.
+
         --no-permissions
             Hide permissions from the long view.
 

--- a/src/cli_args.zig
+++ b/src/cli_args.zig
@@ -23,6 +23,7 @@ pub inline fn parseCliConfig(allocator: std.mem.Allocator, res: anytype) !CliCon
 
     // Render visibility flags are part of the parsed CLI config.
     const long_view_opt = render.LongViewOptions{
+        .header = res.args.header == 1,
         .show_permissions = res.args.@"no-permissions" == 0,
         .show_user = res.args.@"no-user" == 0,
         .show_group = res.args.@"no-group" == 0,

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,6 +12,7 @@ const params_desc: []const u8 = blk: {
     break :blk
     \\-h, --help                       Usage: zl [OPTIONS] [PATH]...
     \\-l, --long                       Show the long view.
+    \\    --header                     Show header in the long view.
     \\    --no-permissions             Hide permissions from the long view.
     \\    --no-user                    Hide user from the long view.
     \\    --no-group                   Hide group from the long view.

--- a/src/render.zig
+++ b/src/render.zig
@@ -16,6 +16,7 @@ const ModeOptionsComptime = struct {
 };
 
 pub const LongViewOptions = struct {
+    header: bool = false,
     show_permissions: bool = true,
     show_user: bool = true,
     show_group: bool = true,
@@ -206,12 +207,10 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
 
     const show_git = files.hasGitStatus() and !mode_opt.pure;
 
-    const show_header = true;
-
-    const git_len: usize = if (show_header) 3 else 1;
-    var user_len: usize = if (show_header) 4 else 0;
-    var group_len: usize = if (show_header) 5 else 0;
-    var time_len: usize = if (show_header) 4 else 0;
+    const git_len: usize = if (view_opt.header) 3 else 1;
+    var user_len: usize = if (view_opt.header) 4 else 0;
+    var group_len: usize = if (view_opt.header) 5 else 0;
+    var time_len: usize = if (view_opt.header) 4 else 0;
 
     for (files.entries()) |val| {
         user_len = @max(user_len, val.username.len);
@@ -220,7 +219,7 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
         time_len = @max(time_len, (try val.formatTime(&time_buf)).len);
     }
 
-    if (show_header) {
+    if (view_opt.header) {
         if (show_git) try term.writer.print("Git ", .{});
         if (view_opt.show_permissions) try term.writer.print("Permissions ", .{});
         if (view_opt.show_user) try term.writer.print("{s:<[1]} ", .{ "User", user_len });

--- a/src/render.zig
+++ b/src/render.zig
@@ -220,13 +220,13 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
     }
 
     if (show_header) {
+        if (show_git) try term.writer.print("Git ", .{});
         if (view_opt.show_permissions) try term.writer.print("Permissions ", .{});
         if (view_opt.show_user) try term.writer.print("{s:<[1]} ", .{ "User", user_len });
         if (view_opt.show_group) try term.writer.print("{s:<[1]} ", .{ "Group", group_len });
         if (view_opt.show_size) try term.writer.print("Size ", .{});
         if (view_opt.show_time) try term.writer.print("{s:<[1]} ", .{ "Time", time_len });
-        try term.writer.print("Name ", .{});
-        try term.writer.print("\n", .{});
+        try term.writer.print("Name\n", .{});
     }
 
     for (files.entries()) |val| {
@@ -238,7 +238,7 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
             const git_char = getGitStatusChar(files, val.name) orelse ' ';
             const git_color = getGitStatusColor(files, val.name);
             try term.setColor(git_color);
-            try term.writer.print("{c} ", .{git_char});
+            try term.writer.print("{c}   ", .{git_char});
         }
 
         if (view_opt.show_permissions) try term.writer.print("{s:<11} ", .{val.getPermissions(&perm_buf)});

--- a/src/render.zig
+++ b/src/render.zig
@@ -208,6 +208,7 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
 
     const show_header = true;
 
+    const git_len: u64 = if (show_header) 3 else 1;
     var user_len: u64 = if (show_header) 4 else 0;
     var group_len: u64 = if (show_header) 5 else 0;
     var time_len: u64 = if (show_header) 4 else 0;
@@ -238,7 +239,7 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
             const git_char = getGitStatusChar(files, val.name) orelse ' ';
             const git_color = getGitStatusColor(files, val.name);
             try term.setColor(git_color);
-            try term.writer.print("{c}   ", .{git_char});
+            try term.writer.print("{c:<[1]} ", .{ git_char, git_len });
         }
 
         if (view_opt.show_permissions) try term.writer.print("{s:<11} ", .{val.getPermissions(&perm_buf)});

--- a/src/render.zig
+++ b/src/render.zig
@@ -239,7 +239,7 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
             const git_char = getGitStatusChar(files, val.name) orelse ' ';
             const git_color = getGitStatusColor(files, val.name);
             try term.setColor(git_color);
-            try term.writer.print("{c:<[1]} ", .{ git_char, git_len });
+            try term.writer.print("{c:>[1]} ", .{ git_char, git_len });
         }
 
         if (view_opt.show_permissions) try term.writer.print("{s:<11} ", .{val.getPermissions(&perm_buf)});

--- a/src/render.zig
+++ b/src/render.zig
@@ -208,10 +208,10 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
 
     const show_header = true;
 
-    const git_len: u64 = if (show_header) 3 else 1;
-    var user_len: u64 = if (show_header) 4 else 0;
-    var group_len: u64 = if (show_header) 5 else 0;
-    var time_len: u64 = if (show_header) 4 else 0;
+    const git_len: usize = if (show_header) 3 else 1;
+    var user_len: usize = if (show_header) 4 else 0;
+    var group_len: usize = if (show_header) 5 else 0;
+    var time_len: usize = if (show_header) 4 else 0;
 
     for (files.entries()) |val| {
         user_len = @max(user_len, val.username.len);
@@ -245,8 +245,8 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
         if (view_opt.show_permissions) try term.writer.print("{s:<11} ", .{val.getPermissions(&perm_buf)});
         if (view_opt.show_user) try term.writer.print("{s:<[1]} ", .{ val.username, user_len });
         if (view_opt.show_group) try term.writer.print("{s:<[1]} ", .{ val.groupname, group_len });
-        if (view_opt.show_size) try term.writer.print("{s:<4} ", .{try val.humanSize(&size_buf)});
-        if (view_opt.show_time) try term.writer.print("{s:<[1]} ", .{ try val.formatTime(&time_buf), time_len });
+        if (view_opt.show_size) try term.writer.print("{s:>4} ", .{try val.humanSize(&size_buf)});
+        if (view_opt.show_time) try term.writer.print("{s:>[1]} ", .{ try val.formatTime(&time_buf), time_len });
         if (view_opt.show_icon and !mode_opt.pure) try term.writer.print("{s} ", .{getIcon(val.is_dir, val.name)});
         try term.writer.print("{s}", .{try val.formatLongDisplayName(&display_name_buf)});
 

--- a/src/render.zig
+++ b/src/render.zig
@@ -206,6 +206,29 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
 
     const show_git = files.hasGitStatus() and !mode_opt.pure;
 
+    const show_header = true;
+
+    var user_len: u64 = if (show_header) 4 else 0;
+    var group_len: u64 = if (show_header) 5 else 0;
+    var time_len: u64 = if (show_header) 4 else 0;
+
+    for (files.entries()) |val| {
+        user_len = @max(user_len, val.username.len);
+        group_len = @max(group_len, val.groupname.len);
+        // TODO: Possibly extract this formatting as it's used later again
+        time_len = @max(time_len, (try val.formatTime(&time_buf)).len);
+    }
+
+    if (show_header) {
+        if (view_opt.show_permissions) try term.writer.print("Permissions ", .{});
+        if (view_opt.show_user) try term.writer.print("{s:<[1]} ", .{ "User", user_len });
+        if (view_opt.show_group) try term.writer.print("{s:<[1]} ", .{ "Group", group_len });
+        if (view_opt.show_size) try term.writer.print("Size ", .{});
+        if (view_opt.show_time) try term.writer.print("{s:<[1]} ", .{ "Time", time_len });
+        try term.writer.print("Name ", .{});
+        try term.writer.print("\n", .{});
+    }
+
     for (files.entries()) |val| {
         if (!mode_opt.pure) {
             try term.setColor(getColor(val.is_dir, val.name));
@@ -219,10 +242,10 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
         }
 
         if (view_opt.show_permissions) try term.writer.print("{s:<11} ", .{val.getPermissions(&perm_buf)});
-        if (view_opt.show_user) try term.writer.print("{s:<8} ", .{val.username});
-        if (view_opt.show_group) try term.writer.print("{s:<8} ", .{val.groupname});
-        if (view_opt.show_size) try term.writer.print("{s:<8} ", .{try val.humanSize(&size_buf)});
-        if (view_opt.show_time) try term.writer.print("{s:<8} ", .{try val.formatTime(&time_buf)});
+        if (view_opt.show_user) try term.writer.print("{s:<[1]} ", .{ val.username, user_len });
+        if (view_opt.show_group) try term.writer.print("{s:<[1]} ", .{ val.groupname, group_len });
+        if (view_opt.show_size) try term.writer.print("{s:<4} ", .{try val.humanSize(&size_buf)});
+        if (view_opt.show_time) try term.writer.print("{s:<[1]} ", .{ try val.formatTime(&time_buf), time_len });
         if (view_opt.show_icon and !mode_opt.pure) try term.writer.print("{s} ", .{getIcon(val.is_dir, val.name)});
         try term.writer.print("{s}", .{try val.formatLongDisplayName(&display_name_buf)});
 

--- a/src/render.zig
+++ b/src/render.zig
@@ -215,7 +215,6 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
     for (files.entries()) |val| {
         user_len = @max(user_len, val.username.len);
         group_len = @max(group_len, val.groupname.len);
-        // TODO: Possibly extract this formatting as it's used later again
         time_len = @max(time_len, (try val.formatTime(&time_buf)).len);
     }
 

--- a/src/render.zig
+++ b/src/render.zig
@@ -247,7 +247,7 @@ pub fn listDetail(files: zlist.Files, term: Terminal, comptime mode_opt: ModeOpt
         if (view_opt.show_group) try term.writer.print("{s:<[1]} ", .{ val.groupname, group_len });
         if (view_opt.show_size) try term.writer.print("{s:>4} ", .{try val.humanSize(&size_buf)});
         if (view_opt.show_time) try term.writer.print("{s:>[1]} ", .{ try val.formatTime(&time_buf), time_len });
-        if (view_opt.show_icon and !mode_opt.pure) try term.writer.print("{s} ", .{getIcon(val.is_dir, val.name)});
+        if (view_opt.show_icon and !mode_opt.pure) try term.writer.print("{s}", .{getIcon(val.is_dir, val.name)});
         try term.writer.print("{s}", .{try val.formatLongDisplayName(&display_name_buf)});
 
         if (!mode_opt.pure) {


### PR DESCRIPTION
This PR aims to implement an optional header for the long view, and make column size dynamic.

This is how it should look like:
```
ls -la -G=before
Permissions User Group Size Time                     Name
drwxr-xr-x  nn   nn    4K   Jul 16 13:48:34 UTC 2026   .git
drwxr-xr-x  nn   nn    4K   Jun 30 19:35:48 UTC 2026   .github
drwxr-xr-x  nn   nn    4K   Jun 30 19:37:07 UTC 2026   .zig-cache
drwxr-xr-x  nn   nn    4K   Jul 09 08:39:26 UTC 2026   docs
drwxr-xr-x  nn   nn    4K   Jul 08 03:29:52 UTC 2026   pics
drwxr-xr-x  nn   nn    4K   Jul 16 13:47:10 UTC 2026   src
drwxr-xr-x  nn   nn    4K   Jun 30 19:42:08 UTC 2026   zig-out
drwxr-xr-x  nn   nn    4K   Jun 30 19:37:03 UTC 2026   zig-pkg
-rw-r--r--  nn   nn    30B  Jun 30 19:35:48 UTC 2026   .gitignore
-rw-r--r--  nn   nn    1K   Jul 01 13:12:05 UTC 2026   build.zig
-rw-r--r--  nn   nn    490B Jul 09 08:39:26 UTC 2026   build.zig.zon
-rw-r--r--  nn   nn    1K   Jun 30 19:35:48 UTC 2026   LICENSE
-rw-r--r--  nn   nn    7K   Jul 16 13:47:05 UTC 2026   README.md
```

closes #76 