### PR TITLE
feat: Dir symlinks

### DIFF
--- a/src/zlist/file.zig
+++ b/src/zlist/file.zig
@@ -79,6 +79,7 @@ inline fn formatExecPermission(mode: u32, exec_bit: u16, special_bit: u16, speci
 pub const File = struct {
     const Self = @This();
     is_dir: bool,
+    is_symlink_to_dir: bool,
     is_exec: bool,
     is_hidden: bool,
     name: []const u8,
@@ -101,6 +102,7 @@ pub const File = struct {
         groupname_inventory: *std.AutoHashMap(std.c.gid_t, []const u8),
     ) !?Self {
         const is_dir: bool = (entry.kind == .directory);
+        const is_symlink_to_dir: bool = (try dir.statFile(io, entry.name, .{})).kind == .directory;
         const is_hidden: bool = (entry.name[0] == '.');
 
         if (!opt.show_hidden and is_hidden) {
@@ -130,6 +132,7 @@ pub const File = struct {
         var file: Self = .{
             .is_hidden = is_hidden,
             .is_dir = is_dir,
+            .is_symlink_to_dir = is_symlink_to_dir,
             .is_exec = false,
             .name = entry.name,
             .stat_t = null,
@@ -291,6 +294,7 @@ pub const File = struct {
     pub inline fn statForName(name: []const u8, dir: *const std.Io.Dir) ?Stat {
         const temp_file = Self{
             .is_dir = false,
+            .is_symlink_to_dir = false,
             .is_exec = false,
             .is_hidden = false,
             .name = name,

--- a/src/zlist/files.zig
+++ b/src/zlist/files.zig
@@ -137,7 +137,7 @@ pub const Files = struct {
             loaded_git = true;
         }
 
-        sort(files.items, opt.dir_grouping, opt.sort_type, opt.reverse);
+        sort(files.items, opt.dir_grouping, opt.sort_type, opt.reverse, io, dir);
 
         return .{
             .max_display_len = max_len,
@@ -367,12 +367,14 @@ pub const Files = struct {
         sort_type: opts.SortType,
         dir_grouping: opts.DirGrouping,
         reverse: bool,
+        io: std.Io,
+        dir: std.Io.Dir,
 
         fn lessThan(ctx: SortCtx, a: file.File, b: file.File) bool {
             if (ctx.dir_grouping != .none) {
-                const a_dir = a.is_dir;
-                const b_dir = b.is_dir;
-                if (a_dir != b_dir) return a_dir == (ctx.dir_grouping == .before);
+                const a_is_dir = if (a.symlink_target) |target| isDir(target, ctx.io, ctx.dir) else a.is_dir;
+                const b_is_dir = if (b.symlink_target) |target| isDir(target, ctx.io, ctx.dir) else b.is_dir;
+                if (a_is_dir != b_is_dir) return a_is_dir == (ctx.dir_grouping == .before);
             }
 
             const res = switch (ctx.sort_type) {
@@ -384,9 +386,14 @@ pub const Files = struct {
 
             return if (ctx.reverse) !res else res;
         }
+
+        fn isDir(path: []const u8, io: std.Io, dir: std.Io.Dir) bool {
+            const stat = dir.statFile(io, path, .{}) catch return false;
+            return stat.kind == .directory;
+        }
     };
 
-    fn sort(items: []file.File, dir_grouping: opts.DirGrouping, sort_type: opts.SortType, reverse: bool) void {
+    fn sort(items: []file.File, dir_grouping: opts.DirGrouping, sort_type: opts.SortType, reverse: bool, io: std.Io, dir: std.Io.Dir) void {
         mem.sortUnstable(
             file.File,
             items,
@@ -394,6 +401,8 @@ pub const Files = struct {
                 .dir_grouping = dir_grouping,
                 .sort_type = sort_type,
                 .reverse = reverse,
+                .io = io,
+                .dir = dir,
             },
             SortCtx.lessThan,
         );

--- a/src/zlist/files.zig
+++ b/src/zlist/files.zig
@@ -137,7 +137,7 @@ pub const Files = struct {
             loaded_git = true;
         }
 
-        sort(files.items, opt.dir_grouping, opt.sort_type, opt.reverse, io, dir);
+        sort(files.items, opt.dir_grouping, opt.sort_type, opt.reverse);
 
         return .{
             .max_display_len = max_len,
@@ -367,13 +367,11 @@ pub const Files = struct {
         sort_type: opts.SortType,
         dir_grouping: opts.DirGrouping,
         reverse: bool,
-        io: std.Io,
-        dir: std.Io.Dir,
 
         fn lessThan(ctx: SortCtx, a: file.File, b: file.File) bool {
             if (ctx.dir_grouping != .none) {
-                const a_is_dir = if (a.symlink_target) |target| isDir(target, ctx.io, ctx.dir) else a.is_dir;
-                const b_is_dir = if (b.symlink_target) |target| isDir(target, ctx.io, ctx.dir) else b.is_dir;
+                const a_is_dir = a.is_dir or a.is_symlink_to_dir;
+                const b_is_dir = b.is_dir or b.is_symlink_to_dir;
                 if (a_is_dir != b_is_dir) return a_is_dir == (ctx.dir_grouping == .before);
             }
 
@@ -393,7 +391,7 @@ pub const Files = struct {
         }
     };
 
-    fn sort(items: []file.File, dir_grouping: opts.DirGrouping, sort_type: opts.SortType, reverse: bool, io: std.Io, dir: std.Io.Dir) void {
+    fn sort(items: []file.File, dir_grouping: opts.DirGrouping, sort_type: opts.SortType, reverse: bool) void {
         mem.sortUnstable(
             file.File,
             items,
@@ -401,8 +399,6 @@ pub const Files = struct {
                 .dir_grouping = dir_grouping,
                 .sort_type = sort_type,
                 .reverse = reverse,
-                .io = io,
-                .dir = dir,
             },
             SortCtx.lessThan,
         );


### PR DESCRIPTION
I currently only handled sorting.
It still uses the file icon/col instead of a dir icon/col, and is quite bad performance wise.
This checks whether a symlink is a dir each time it appears in the `lessThan` fn, and I'd suggest extracting the `is_symlink_dir` into a variable found under the `File` struct for both performance and ease of use.
It would help with the icon/col implementation too.
I'd like to hear your thoughts on this.

<img width="807" height="1214" alt="image" src="https://github.com/user-attachments/assets/3038f431-3d54-4d35-aa18-c3f47292fcc7" />

closes #78 