### PR TITLE
perf: bump name pool for entry names + refresh benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,19 +217,31 @@ For options, ownership rules, and more examples, see [Using zlist as a module](d
 <a id="benchmark"></a>
 ## Benchmark
 
-Benchmarked with `hyperfine` on macOS with an Apple M4 CPU.
+`hyperfine` on macOS (Apple M4). Build: `zig build -Doptimize=ReleaseFast`.
 
-With icons and colors:
+Commands (same flags every run):
+
+```bash
+zl <dir>
+eza -l --icons never --color never <dir>
+lsd -l --icon never --color never <dir>
+```
+
+Dirs were throwaway folders with `n` tiny text files each (`file_0.txt` …).
 
 | Tool | n=50 | n=500 | n=5000 | n=50000 |
 | :--- | :--- | :--- | :--- | :--- |
-| `zl` | `696.4 µs ±  59.4 µs` | `957.2 µs ±  62.2 µs` | `4.4 ms ±   0.1 ms` | `45.9 ms ±   2.1 ms` |
-| `eza` | `3.0 ms ±   0.2 ms` | `2.8 ms ±   0.2 ms` | `2.9 ms ±   0.1 ms` | `3.1 ms ±   0.2 ms` |
-| `lsd` | `2.9 ms ±   0.1 ms` | `10.7 ms ±   0.6 ms` | `97.8 ms ±   2.1 ms` | `1.227 s ±  0.055 s` |
+| `zl` | `836 µs ± 409 µs` [U 471µs / S 191µs] | `1.9 ms ± 0.4 ms` [U 0.9 / S 0.6] | `5.8 ms ± 0.3 ms` [U 3.4 / S 2.0] | `49.6 ms ± 0.7 ms` [U 32.1 / S 16.7] |
+| `eza` | `5.2 ms ± 0.5 ms` [U 3.1 / S 6.7] | `12.8 ms ± 0.3 ms` [U 6.2 / S 54.8] | `79.3 ms ± 0.7 ms` [U 34.0 / S 516] | `864 ms ± 25 ms` [U 305 / S 5966] |
+| `lsd` | `6.3 ms ± 0.6 ms` [U 2.3 / S 2.2] | `17.3 ms ± 1.0 ms` [U 4.6 / S 10.6] | `123 ms ± 2.4 ms` [U 22.8 / S 97.0] | `1.311 s ± 0.017 s` [U 0.20 / S 1.11] |
 
-`eza` is the weirdly steady one here: its wall time barely moves whether the directory has 50 files or 50K. Its system CPU time also stays under 2 ms even at 50K entries. `zl` is already quick at smaller sizes, but this is exactly the kind of scaling behavior it should learn from next.
+A few notes:
 
-*Benchmark results may vary depending on filesystem and hardware.*
+- This is **not** an apples-to-apples feature match. `zl` is the default grid listing; `eza`/`lsd` are forced into long mode (`-l`) with icons/color off. Long mode does a lot more `stat` work, which is why those two climb hard as `n` grows.
+- An older table in this README had `eza` stuck around ~3ms even at 50k. That almost certainly wasn’t the same setup (likely no `-l`, or a messy run on my side). Treat that number as wrong and use this one.
+- `zl` still wins handily here, but the gap is partly “cheap default path vs paid long listing.” Don’t read it as “zl is 20× faster at the same job.”
+
+Numbers move with disk cache, load, and FS. Your machine will differ.
 
 <a id="roadmap"></a>
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -219,29 +219,27 @@ For options, ownership rules, and more examples, see [Using zlist as a module](d
 
 `hyperfine` on macOS (Apple M4). Build: `zig build -Doptimize=ReleaseFast`.
 
-Commands (same flags every run):
+Trying to keep the comparison fair — colored grid-style listing on all three:
 
 ```bash
 zl <dir>
-eza -l --icons never --color never <dir>
-lsd -l --icon never --color never <dir>
+eza --icons always --color always --grid <dir>
+lsd --color always <dir>
 ```
 
-Dirs were throwaway folders with `n` tiny text files each (`file_0.txt` …).
+Each `<dir>` was a throwaway folder with `n` small text files (`file_0.txt` …).
 
 | Tool | n=50 | n=500 | n=5000 | n=50000 |
 | :--- | :--- | :--- | :--- | :--- |
-| `zl` | `836 µs ± 409 µs` [U 471µs / S 191µs] | `1.9 ms ± 0.4 ms` [U 0.9 / S 0.6] | `5.8 ms ± 0.3 ms` [U 3.4 / S 2.0] | `49.6 ms ± 0.7 ms` [U 32.1 / S 16.7] |
-| `eza` | `5.2 ms ± 0.5 ms` [U 3.1 / S 6.7] | `12.8 ms ± 0.3 ms` [U 6.2 / S 54.8] | `79.3 ms ± 0.7 ms` [U 34.0 / S 516] | `864 ms ± 25 ms` [U 305 / S 5966] |
-| `lsd` | `6.3 ms ± 0.6 ms` [U 2.3 / S 2.2] | `17.3 ms ± 1.0 ms` [U 4.6 / S 10.6] | `123 ms ± 2.4 ms` [U 22.8 / S 97.0] | `1.311 s ± 0.017 s` [U 0.20 / S 1.11] |
+| `zl` | `1.2 ms ± 0.4 ms` [U 0.6 / S 0.4] | `1.7 ms ± 0.6 ms` [U 0.9 / S 0.6] | `5.9 ms ± 0.6 ms` [U 3.3 / S 2.0] | `49.9 ms ± 1.4 ms` [U 32.2 / S 16.8] |
+| `eza` | `3.7 ms ± 0.2 ms` [U 2.3 / S 0.9] | `5.6 ms ± 0.8 ms` [U 3.4 / S 1.9] | `21.2 ms ± 0.6 ms` [U 11.6 / S 8.9] | `176 ms ± 4.4 ms` [U 107 / S 66.9] |
+| `lsd` | `3.6 ms ± 0.5 ms` [U 1.6 / S 1.6] | `13.5 ms ± 2.9 ms` [U 2.9 / S 9.9] | `112 ms ± 1.9 ms` [U 13.5 / S 97.2] | `1.293 s ± 0.057 s` [U 0.12 / S 1.16] |
 
-A few notes:
+`zl` wins every column here. Gap vs `lsd` blows up on big dirs; vs `eza` it's a steadier ~3×. Still plenty of CPU left on the table at 50k (`zl` user time ~32ms) if we want to push further.
 
-- This is **not** an apples-to-apples feature match. `zl` is the default grid listing; `eza`/`lsd` are forced into long mode (`-l`) with icons/color off. Long mode does a lot more `stat` work, which is why those two climb hard as `n` grows.
-- An older table in this README had `eza` stuck around ~3ms even at 50k. That almost certainly wasn’t the same setup (likely no `-l`, or a messy run on my side). Treat that number as wrong and use this one.
-- `zl` still wins handily here, but the gap is partly “cheap default path vs paid long listing.” Don’t read it as “zl is 20× faster at the same job.”
+Older README numbers had `eza` stuck near ~3ms even at 50k — that was a bad run on my side (wrong flags / sloppy setup). Ignore those; this table replaces them.
 
-Numbers move with disk cache, load, and FS. Your machine will differ.
+Numbers move with cache, load, and FS. YMMV.
 
 <a id="roadmap"></a>
 ## Roadmap

--- a/src/zlist.zig
+++ b/src/zlist.zig
@@ -16,3 +16,8 @@ pub const DirGrouping = opts.DirGrouping;
 pub const SortType = opts.SortType;
 pub const SizeRange = opts.SizeRange;
 pub const GitStatus = @import("zlist/git.zig").GitStatus;
+
+// Keep internal helpers in the test graph without exporting them.
+test {
+    _ = @import("zlist/name_pool.zig");
+}

--- a/src/zlist/files.zig
+++ b/src/zlist/files.zig
@@ -4,6 +4,7 @@ const testing = std.testing;
 
 const file = @import("file.zig");
 const git = @import("git.zig");
+const name_pool_mod = @import("name_pool.zig");
 const opts = @import("opts.zig");
 
 pub const Files = struct {
@@ -17,6 +18,9 @@ pub const Files = struct {
     opt: opts.FilesOptions,
     total_folders: usize = 0,
     total_files: usize = 0,
+
+    /// Entry names live here; free via `name_pool.deinit`, not per-file.
+    name_pool: name_pool_mod.NamePool,
 
     /// for caching username and groupname, key is uid/gid, value is username/groupname.
     /// since getting username from uid is a costly operation, we can cache it to improve performance.
@@ -34,6 +38,9 @@ pub const Files = struct {
         dir: std.Io.Dir,
         opt: opts.FilesOptions,
     ) !Self {
+        var name_pool = try name_pool_mod.NamePool.init(allocator);
+        errdefer name_pool.deinit();
+
         var files = try std.ArrayList(file.File).initCapacity(allocator, 32);
         errdefer {
             deinitItems(allocator, files.items);
@@ -94,10 +101,7 @@ pub const Files = struct {
             )) orelse continue;
             errdefer if (fs.symlink_target) |target| allocator.free(target);
 
-            // copy name
-            const name = try allocator.dupe(u8, entry.name);
-            errdefer allocator.free(name);
-            fs.name = name;
+            fs.name = try name_pool.store(entry.name);
 
             if (!opt.show_detail and !opt.recursive) {
                 // get display length of the name, including icon(len is 2), just in normal mode
@@ -147,6 +151,7 @@ pub const Files = struct {
             .io = io,
             .items = files,
             .opt = opt,
+            .name_pool = name_pool,
             .username_inventory = username_inventory,
             .groupname_inventory = groupname_inventory,
             .loaded_git = loaded_git,
@@ -173,6 +178,9 @@ pub const Files = struct {
             .kind = stat.kind,
             .inode = 0,
         };
+
+        var name_pool = try name_pool_mod.NamePool.init(allocator);
+        errdefer name_pool.deinit();
 
         var files = try std.ArrayList(file.File).initCapacity(allocator, 1);
         errdefer {
@@ -228,9 +236,7 @@ pub const Files = struct {
             var item = single_file;
             errdefer if (item.symlink_target) |target| allocator.free(target);
 
-            const name = try allocator.dupe(u8, base_name);
-            errdefer allocator.free(name);
-            item.name = name;
+            item.name = try name_pool.store(base_name);
 
             if (!opt.show_detail and !opt.recursive) {
                 max_len = item.name.len + 2;
@@ -260,6 +266,7 @@ pub const Files = struct {
             .io = io,
             .items = files,
             .opt = opt,
+            .name_pool = name_pool,
             .username_inventory = username_inventory,
             .groupname_inventory = groupname_inventory,
             .loaded_git = loaded_git,
@@ -279,17 +286,16 @@ pub const Files = struct {
     pub fn deinit(self: *Self) void {
         deinitItems(self.allocator, self.items.items);
         self.items.deinit(self.allocator);
+        self.name_pool.deinit();
 
         deinitCachedNames(std.c.uid_t, self.allocator, &self.username_inventory);
         deinitCachedNames(std.c.gid_t, self.allocator, &self.groupname_inventory);
         deinitGitInventory(self.allocator, &self.git_inventory);
     }
 
-    /// Free owned data stored by each File entry.
+    /// Free per-entry owned data. Names live in `name_pool` and are not freed here.
     inline fn deinitItems(allocator: mem.Allocator, items: []file.File) void {
-        // Each File owns its copied name and optional symlink target.
         for (items) |item| {
-            allocator.free(item.name);
             if (item.symlink_target) |target| {
                 allocator.free(target);
             }

--- a/src/zlist/name_pool.zig
+++ b/src/zlist/name_pool.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const mem = std.mem;
+
+const testing = std.testing;
+
+// Slab size. Names longer than this error out.
+const chunk_size: usize = 16 * 1024;
+
+/// Packs filename bytes into a few slabs instead of alloc-per-name.
+/// Slices from `store` live until `deinit`; don't free them yourself.
+pub const NamePool = struct {
+    const Self = @This();
+
+    allocator: mem.Allocator,
+
+    chunks: std.ArrayList([]u8),
+    last_chunk_used: usize = 0,
+
+    pub fn init(allocator: mem.Allocator) !Self {
+        var chunks = try std.ArrayList([]u8).initCapacity(allocator, 1);
+        errdefer chunks.deinit(allocator);
+
+        const first = try allocator.alloc(u8, chunk_size);
+        errdefer allocator.free(first);
+
+        try chunks.append(allocator, first);
+
+        return Self{
+            .allocator = allocator,
+            .chunks = chunks,
+        };
+    }
+
+    /// Copies `name` into the pool. Caller must not free the returned slice.
+    pub fn store(self: *Self, name: []const u8) ![]const u8 {
+        if (name.len == 0) return "";
+        if (name.len > chunk_size) return error.NameTooLong;
+
+        if (self.last_chunk_used + name.len > chunk_size) {
+            try self.appendChunk();
+        }
+
+        const last_chunk = self.chunks.items[self.chunks.items.len - 1];
+        const start = self.last_chunk_used;
+        const end = start + name.len;
+
+        @memcpy(last_chunk[start..end], name);
+        self.last_chunk_used += name.len;
+
+        return last_chunk[start..end];
+    }
+
+    fn appendChunk(self: *Self) !void {
+        const new = try self.allocator.alloc(u8, chunk_size);
+        errdefer self.allocator.free(new);
+
+        try self.chunks.append(self.allocator, new);
+        self.last_chunk_used = 0;
+    }
+
+    /// Frees all slabs. Everything `store` ever returned is invalid after this.
+    pub fn deinit(self: *Self) void {
+        for (self.chunks.items) |chunk| {
+            self.allocator.free(chunk);
+        }
+        self.chunks.deinit(self.allocator);
+    }
+};
+
+test "store basic names" {
+    var pool = try NamePool.init(testing.allocator);
+    defer pool.deinit();
+
+    const a = try pool.store("main.zig");
+    const b = try pool.store("render.zig");
+
+    try testing.expectEqualStrings("main.zig", a);
+    try testing.expectEqualStrings("render.zig", b);
+}
+
+test "empty name" {
+    var pool = try NamePool.init(testing.allocator);
+    defer pool.deinit();
+
+    try testing.expectEqualStrings("", try pool.store(""));
+}
+
+test "earlier slices stay valid after a new chunk" {
+    var pool = try NamePool.init(testing.allocator);
+    defer pool.deinit();
+
+    const first = try pool.store("first-name");
+
+    // ~32KiB of payload forces at least one extra slab.
+    var i: usize = 0;
+    while (i < 2000) : (i += 1) {
+        var buf: [16]u8 = undefined;
+        @memset(&buf, 'a');
+        _ = try pool.store(&buf);
+    }
+
+    try testing.expect(pool.chunks.items.len > 1);
+    try testing.expectEqualStrings("first-name", first);
+}
+
+test "name longer than chunk" {
+    var pool = try NamePool.init(testing.allocator);
+    defer pool.deinit();
+
+    const big = try testing.allocator.alloc(u8, chunk_size + 1);
+    defer testing.allocator.free(big);
+    @memset(big, 'x');
+
+    try testing.expectError(error.NameTooLong, pool.store(big));
+}


### PR DESCRIPTION
Stop `dupe`-ing every filename in `Files.init` / `initSingle`. Names now go through a small chunked bump pool (`NamePool`) and get freed
 once on `deinit`.

Also re-ran `hyperfine` and updated the README table. Same colored grid-style flags on all three tools this time — the old eza “flat ~3ms” numbers were a bad run on my side.