### PR TITLE
Add zon config for symlink icon and color

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zlist,
-    .version = "0.1.10",
+    .version = "0.1.13",
     .dependencies = .{
         .clap = .{
             .url = "git+https://github.com/Hejsil/zig-clap#e91d66b1abba2024cd2e816426f14d233d3dad9a",

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,6 +13,7 @@ Leave a field out and the built-in value sticks. `by_ext` only overrides that ex
     .icons = .{
         .dir = " ",
         .file = " ",
+        .symlink = " ",
         .by_ext = .{
             .{ .ext = ".zig", .icon = " " },
         },
@@ -20,6 +21,7 @@ Leave a field out and the built-in value sticks. `by_ext` only overrides that ex
     .colors = .{
         .dir = "bright_blue",
         .file = "bright_yellow",
+        .symlink = "cyan",
         .by_ext = .{
             .{ .ext = ".md", .color = "bright_magenta" },
         },

--- a/src/cfg.zig
+++ b/src/cfg.zig
@@ -17,11 +17,15 @@ pub const Config = struct {
     dir_icon: []const u8 = " ",
     /// When set, skips the built-in map for files that didn't match `by_ext`.
     file_icon: ?[]const u8 = null,
+    /// When set, used for every symlink instead of the file/ext maps.
+    symlink_icon: ?[]const u8 = null,
     icon_by_ext: []const ExtIcon = &.{},
 
     dir_color: Color = .bright_blue,
     /// Same as `file_icon`.
     file_color: ?Color = null,
+    /// Same as `symlink_icon`.
+    symlink_color: ?Color = null,
     color_by_ext: []const ExtColor = &.{},
 };
 
@@ -33,12 +37,14 @@ const File = struct {
     const Icons = struct {
         dir: ?[]const u8 = null,
         file: ?[]const u8 = null,
+        symlink: ?[]const u8 = null,
         by_ext: ?[]const ExtIcon = null,
     };
 
     const Colors = struct {
         dir: ?[]const u8 = null,
         file: ?[]const u8 = null,
+        symlink: ?[]const u8 = null,
         by_ext: ?[]const RawExtColor = null,
     };
 
@@ -75,12 +81,14 @@ fn configFromFile(allocator: std.mem.Allocator, file: File) !Config {
     if (file.icons) |icons| {
         if (icons.dir) |dir| config.dir_icon = dir;
         if (icons.file) |file_icon| config.file_icon = file_icon;
+        if (icons.symlink) |symlink| config.symlink_icon = symlink;
         if (icons.by_ext) |by_ext| config.icon_by_ext = by_ext;
     }
 
     if (file.colors) |colors| {
         if (colors.dir) |name| config.dir_color = try parseColor(name);
         if (colors.file) |name| config.file_color = try parseColor(name);
+        if (colors.symlink) |name| config.symlink_color = try parseColor(name);
         if (colors.by_ext) |entries| {
             const by_ext = try allocator.alloc(ExtColor, entries.len);
             for (entries, 0..) |entry, i| {
@@ -126,12 +134,14 @@ test "load applies partial overrides" {
         \\.{
         \\    .icons = .{
         \\        .dir = "D ",
+        \\        .symlink = "L ",
         \\        .by_ext = .{
         \\            .{ .ext = ".zig", .icon = "Z " },
         \\        },
         \\    },
         \\    .colors = .{
         \\        .file = "bright_green",
+        \\        .symlink = "cyan",
         \\        .by_ext = .{
         \\            .{ .ext = ".md", .color = "bright_magenta" },
         \\        },
@@ -144,12 +154,14 @@ test "load applies partial overrides" {
 
     try testing.expectEqualStrings("D ", config.dir_icon);
     try testing.expectEqual(@as(?[]const u8, null), config.file_icon);
+    try testing.expectEqualStrings("L ", config.symlink_icon.?);
     try testing.expectEqual(@as(usize, 1), config.icon_by_ext.len);
     try testing.expectEqualStrings(".zig", config.icon_by_ext[0].ext);
     try testing.expectEqualStrings("Z ", config.icon_by_ext[0].icon);
 
     try testing.expectEqual(Color.bright_blue, config.dir_color);
     try testing.expectEqual(@as(?Color, .bright_green), config.file_color);
+    try testing.expectEqual(@as(?Color, .cyan), config.symlink_color);
     try testing.expectEqual(@as(usize, 1), config.color_by_ext.len);
     try testing.expectEqualStrings(".md", config.color_by_ext[0].ext);
     try testing.expectEqual(Color.bright_magenta, config.color_by_ext[0].color);
@@ -175,9 +187,11 @@ fn expectDefaultConfig(config: Config) !void {
     const testing = std.testing;
     try testing.expectEqualStrings(" ", config.dir_icon);
     try testing.expectEqual(@as(?[]const u8, null), config.file_icon);
+    try testing.expectEqual(@as(?[]const u8, null), config.symlink_icon);
     try testing.expectEqual(@as(usize, 0), config.icon_by_ext.len);
     try testing.expectEqual(Color.bright_blue, config.dir_color);
     try testing.expectEqual(@as(?Color, null), config.file_color);
+    try testing.expectEqual(@as(?Color, null), config.symlink_color);
     try testing.expectEqual(@as(usize, 0), config.color_by_ext.len);
 }
 

--- a/src/render.zig
+++ b/src/render.zig
@@ -184,10 +184,10 @@ pub fn list(
 
             // Print prefix, icon and name
             if (!mode_opt.pure) {
-                const icon = getIcon(val.is_dir, val.name, config);
+                const icon = getIcon(val.is_dir, val.is_symlink, val.name, config);
                 try term.writer.print("  ", .{});
 
-                try term.setColor(getColor(val.is_dir, val.name, config));
+                try term.setColor(getColor(val.is_dir, val.is_symlink, val.name, config));
                 try term.writer.print("{s}{s}", .{ icon, val.name });
                 try term.setColor(Terminal.Color.reset);
             } else {
@@ -247,7 +247,7 @@ pub fn listDetail(
 
     for (files.entries()) |val| {
         if (!mode_opt.pure) {
-            try term.setColor(getColor(val.is_dir, val.name, config));
+            try term.setColor(getColor(val.is_dir, val.is_symlink, val.name, config));
         }
 
         if (show_git) {
@@ -262,7 +262,7 @@ pub fn listDetail(
         if (view_opt.show_group) try term.writer.print("{s:<[1]} ", .{ val.groupname, group_len });
         if (view_opt.show_size) try term.writer.print("{s:>[1]} ", .{ try val.humanSize(&size_buf), size_len });
         if (view_opt.show_time) try term.writer.print("{s:>[1]} ", .{ try val.formatTime(&time_buf), time_len });
-        if (view_opt.show_icon and !mode_opt.pure) try term.writer.print("{s}", .{getIcon(val.is_dir, val.name, config)});
+        if (view_opt.show_icon and !mode_opt.pure) try term.writer.print("{s}", .{getIcon(val.is_dir, val.is_symlink, val.name, config)});
         try term.writer.print("{s}", .{try val.formatLongDisplayName(&display_name_buf)});
 
         if (!mode_opt.pure) {
@@ -288,8 +288,8 @@ pub fn listRecursive(
         switch (root_display) {
             .dot => try term.writer.print(".\n", .{}),
             .name => {
-                try term.setColor(getColor(true, root_dir, config));
-                try term.writer.print("{s}{s}\n", .{ getIcon(true, root_dir, config), root_dir });
+                try term.setColor(getColor(true, false, root_dir, config));
+                try term.writer.print("{s}{s}\n", .{ getIcon(true, false, root_dir, config), root_dir });
                 try term.setColor(Terminal.Color.reset);
             },
             .none => {},
@@ -323,10 +323,10 @@ pub fn listRecursive(
 
         // print file/directory name
         if (!mode_opt.pure) {
-            try term.setColor(getColor(val.is_dir, val.name, config));
+            try term.setColor(getColor(val.is_dir, val.is_symlink, val.name, config));
 
             try term.writer.print(comptime PrintMode.RecursiveWithFileMeta.toString(), .{
-                getIcon(val.is_dir, val.name, config),
+                getIcon(val.is_dir, val.is_symlink, val.name, config),
                 val.name,
             });
         } else {
@@ -425,8 +425,11 @@ inline fn getTerminalWidth(handle: std.Io.File.Handle) usize {
     return 80;
 }
 
-inline fn getIcon(is_dir: bool, name: []const u8, config: cfg.Config) []const u8 {
+inline fn getIcon(is_dir: bool, is_symlink: bool, name: []const u8, config: cfg.Config) []const u8 {
     if (is_dir) return config.dir_icon;
+    if (is_symlink) {
+        if (config.symlink_icon) |icon| return icon;
+    }
 
     const ext = std.fs.path.extension(name);
     for (config.icon_by_ext) |entry| {
@@ -438,8 +441,11 @@ inline fn getIcon(is_dir: bool, name: []const u8, config: cfg.Config) []const u8
     return " ";
 }
 
-inline fn getColor(is_dir: bool, name: []const u8, config: cfg.Config) Terminal.Color {
+inline fn getColor(is_dir: bool, is_symlink: bool, name: []const u8, config: cfg.Config) Terminal.Color {
     if (is_dir) return config.dir_color;
+    if (is_symlink) {
+        if (config.symlink_color) |color| return color;
+    }
 
     const ext = std.fs.path.extension(name);
     for (config.color_by_ext) |entry| {

--- a/src/zlist/file.zig
+++ b/src/zlist/file.zig
@@ -89,6 +89,7 @@ inline fn formatExecPermission(mode: u32, exec_bit: u16, special_bit: u16, speci
 pub const File = struct {
     const Self = @This();
     is_dir: bool,
+    is_symlink: bool,
     is_symlink_to_dir: bool,
     is_exec: bool,
     is_hidden: bool,
@@ -112,6 +113,7 @@ pub const File = struct {
         groupname_inventory: *std.AutoHashMap(std.c.gid_t, []const u8),
     ) !?Self {
         const is_dir: bool = (entry.kind == .directory);
+        const is_symlink: bool = (entry.kind == .sym_link);
         const is_hidden: bool = (entry.name[0] == '.');
 
         if (!opt.show_hidden and is_hidden) {
@@ -148,6 +150,7 @@ pub const File = struct {
         var file: Self = .{
             .is_hidden = is_hidden,
             .is_dir = is_dir,
+            .is_symlink = is_symlink,
             .is_symlink_to_dir = is_symlink_to_dir,
             .is_exec = false,
             .name = entry.name,
@@ -310,6 +313,7 @@ pub const File = struct {
     pub inline fn statForName(name: []const u8, dir: *const std.Io.Dir) ?Stat {
         const temp_file = Self{
             .is_dir = false,
+            .is_symlink = false,
             .is_symlink_to_dir = false,
             .is_exec = false,
             .is_hidden = false,


### PR DESCRIPTION
You can now style symlinks in the zon file, same as files. We don't chase the target — a link's a link. Leave it unset and nothing changes.