### PR TITLE
feat: Added more symlink config and made behavior more consistent

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -14,6 +14,7 @@ Leave a field out and the built-in value sticks. `by_ext` only overrides that ex
         .dir = " ",
         .file = " ",
         .symlink = " ",
+        .dir_symlink = " ",
         .by_ext = .{
             .{ .ext = ".zig", .icon = " " },
         },
@@ -21,11 +22,14 @@ Leave a field out and the built-in value sticks. `by_ext` only overrides that ex
     .colors = .{
         .dir = "bright_blue",
         .file = "bright_yellow",
-        .symlink = "cyan",
+        .symlink = "bright_cyan",
+        .dir_symlink = "bright_cyan",
         .by_ext = .{
             .{ .ext = ".md", .color = "bright_magenta" },
         },
     },
+    .inherit_symlink = false,
+    .inherit_dir_symlink = false,
 }
 ```
 

--- a/src/cfg.zig
+++ b/src/cfg.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-
 const Color = std.Io.Terminal.Color;
 
 pub const ExtIcon = struct {
@@ -17,8 +16,10 @@ pub const Config = struct {
     dir_icon: []const u8 = " ",
     /// When set, skips the built-in map for files that didn't match `by_ext`.
     file_icon: ?[]const u8 = null,
-    /// When set, used for every symlink instead of the file/ext maps.
+    /// When set, used for every file symlink
     symlink_icon: ?[]const u8 = null,
+    /// When set, used for every dir symlink
+    dir_symlink_icon: ?[]const u8 = null,
     icon_by_ext: []const ExtIcon = &.{},
 
     dir_color: Color = .bright_blue,
@@ -26,18 +27,28 @@ pub const Config = struct {
     file_color: ?Color = null,
     /// Same as `symlink_icon`.
     symlink_color: ?Color = null,
+    /// Same as `dir_symlink_icon`.
+    dir_symlink_color: ?Color = null,
     color_by_ext: []const ExtColor = &.{},
+
+    /// When true, inherits the icon and color for symlinks
+    inherit_symlink: bool = false,
+    /// When true, inherits the icon and color for dir symlinks
+    inherit_dir_symlink: bool = false,
 };
 
 /// ZON wire format. Every field is optional so partial files keep defaults.
 const File = struct {
     icons: ?Icons = null,
     colors: ?Colors = null,
+    inherit_symlink: ?bool = null,
+    inherit_dir_symlink: ?bool = null,
 
     const Icons = struct {
         dir: ?[]const u8 = null,
         file: ?[]const u8 = null,
         symlink: ?[]const u8 = null,
+        dir_symlink: ?[]const u8 = null,
         by_ext: ?[]const ExtIcon = null,
     };
 
@@ -45,6 +56,7 @@ const File = struct {
         dir: ?[]const u8 = null,
         file: ?[]const u8 = null,
         symlink: ?[]const u8 = null,
+        dir_symlink: ?[]const u8 = null,
         by_ext: ?[]const RawExtColor = null,
     };
 
@@ -82,6 +94,7 @@ fn configFromFile(allocator: std.mem.Allocator, file: File) !Config {
         if (icons.dir) |dir| config.dir_icon = dir;
         if (icons.file) |file_icon| config.file_icon = file_icon;
         if (icons.symlink) |symlink| config.symlink_icon = symlink;
+        if (icons.dir_symlink) |dir_symlink| config.dir_symlink_icon = dir_symlink;
         if (icons.by_ext) |by_ext| config.icon_by_ext = by_ext;
     }
 
@@ -89,6 +102,7 @@ fn configFromFile(allocator: std.mem.Allocator, file: File) !Config {
         if (colors.dir) |name| config.dir_color = try parseColor(name);
         if (colors.file) |name| config.file_color = try parseColor(name);
         if (colors.symlink) |name| config.symlink_color = try parseColor(name);
+        if (colors.dir_symlink) |name| config.dir_symlink_color = try parseColor(name);
         if (colors.by_ext) |entries| {
             const by_ext = try allocator.alloc(ExtColor, entries.len);
             for (entries, 0..) |entry, i| {
@@ -100,6 +114,9 @@ fn configFromFile(allocator: std.mem.Allocator, file: File) !Config {
             config.color_by_ext = by_ext;
         }
     }
+
+    if (file.inherit_symlink) |inherit_symlink| config.inherit_symlink = inherit_symlink;
+    if (file.inherit_dir_symlink) |inherit_dir_symlink| config.inherit_dir_symlink = inherit_dir_symlink;
 
     return config;
 }

--- a/src/render.zig
+++ b/src/render.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
 const Terminal = std.Io.Terminal;
 
-const cfg = @import("cfg.zig");
 const zlist = @import("zlist");
+
+const cfg = @import("cfg.zig");
 
 /// The render options that are determined at compile time.
 const ModeOptionsComptime = struct {
@@ -184,10 +185,10 @@ pub fn list(
 
             // Print prefix, icon and name
             if (!mode_opt.pure) {
-                const icon = getIcon(val.is_dir, val.is_symlink, val.name, config);
+                const icon = getIcon(val.is_dir, val.is_symlink, val.is_symlink_to_dir, val.name, config);
                 try term.writer.print("  ", .{});
 
-                try term.setColor(getColor(val.is_dir, val.is_symlink, val.name, config));
+                try term.setColor(getColor(val.is_dir, val.is_symlink, val.is_symlink_to_dir, val.name, config));
                 try term.writer.print("{s}{s}", .{ icon, val.name });
                 try term.setColor(Terminal.Color.reset);
             } else {
@@ -247,7 +248,7 @@ pub fn listDetail(
 
     for (files.entries()) |val| {
         if (!mode_opt.pure) {
-            try term.setColor(getColor(val.is_dir, val.is_symlink, val.name, config));
+            try term.setColor(getColor(val.is_dir, val.is_symlink, val.is_symlink_to_dir, val.name, config));
         }
 
         if (show_git) {
@@ -262,7 +263,7 @@ pub fn listDetail(
         if (view_opt.show_group) try term.writer.print("{s:<[1]} ", .{ val.groupname, group_len });
         if (view_opt.show_size) try term.writer.print("{s:>[1]} ", .{ try val.humanSize(&size_buf), size_len });
         if (view_opt.show_time) try term.writer.print("{s:>[1]} ", .{ try val.formatTime(&time_buf), time_len });
-        if (view_opt.show_icon and !mode_opt.pure) try term.writer.print("{s}", .{getIcon(val.is_dir, val.is_symlink, val.name, config)});
+        if (view_opt.show_icon and !mode_opt.pure) try term.writer.print("{s}", .{getIcon(val.is_dir, val.is_symlink, val.is_symlink_to_dir, val.name, config)});
         try term.writer.print("{s}", .{try val.formatLongDisplayName(&display_name_buf)});
 
         if (!mode_opt.pure) {
@@ -288,8 +289,8 @@ pub fn listRecursive(
         switch (root_display) {
             .dot => try term.writer.print(".\n", .{}),
             .name => {
-                try term.setColor(getColor(true, false, root_dir, config));
-                try term.writer.print("{s}{s}\n", .{ getIcon(true, false, root_dir, config), root_dir });
+                try term.setColor(getColor(true, false, false, root_dir, config));
+                try term.writer.print("{s}{s}\n", .{ getIcon(true, false, false, root_dir, config), root_dir });
                 try term.setColor(Terminal.Color.reset);
             },
             .none => {},
@@ -323,10 +324,10 @@ pub fn listRecursive(
 
         // print file/directory name
         if (!mode_opt.pure) {
-            try term.setColor(getColor(val.is_dir, val.is_symlink, val.name, config));
+            try term.setColor(getColor(val.is_dir, val.is_symlink, val.is_symlink_to_dir, val.name, config));
 
             try term.writer.print(comptime PrintMode.RecursiveWithFileMeta.toString(), .{
-                getIcon(val.is_dir, val.is_symlink, val.name, config),
+                getIcon(val.is_dir, val.is_symlink, val.is_symlink_to_dir, val.name, config),
                 val.name,
             });
         } else {
@@ -425,10 +426,19 @@ inline fn getTerminalWidth(handle: std.Io.File.Handle) usize {
     return 80;
 }
 
-inline fn getIcon(is_dir: bool, is_symlink: bool, name: []const u8, config: cfg.Config) []const u8 {
+inline fn getIcon(is_dir: bool, is_symlink: bool, is_symlink_to_dir: bool, name: []const u8, config: cfg.Config) []const u8 {
     if (is_dir) return config.dir_icon;
+
     if (is_symlink) {
-        if (config.symlink_icon) |icon| return icon;
+        if (is_symlink_to_dir) {
+            if (config.inherit_dir_symlink) return config.dir_icon;
+            if (config.dir_symlink_icon) |icon| return icon;
+            return " ";
+        }
+        if (!config.inherit_symlink) {
+            if (config.symlink_icon) |icon| return icon;
+            return " ";
+        }
     }
 
     const ext = std.fs.path.extension(name);
@@ -441,10 +451,19 @@ inline fn getIcon(is_dir: bool, is_symlink: bool, name: []const u8, config: cfg.
     return " ";
 }
 
-inline fn getColor(is_dir: bool, is_symlink: bool, name: []const u8, config: cfg.Config) Terminal.Color {
+inline fn getColor(is_dir: bool, is_symlink: bool, is_symlink_to_dir: bool, name: []const u8, config: cfg.Config) Terminal.Color {
     if (is_dir) return config.dir_color;
+
     if (is_symlink) {
-        if (config.symlink_color) |color| return color;
+        if (is_symlink_to_dir) {
+            if (config.inherit_dir_symlink) return config.dir_color;
+            if (config.dir_symlink_color) |color| return color;
+            return .bright_cyan;
+        }
+        if (!config.inherit_symlink) {
+            if (config.symlink_color) |color| return color;
+            return .bright_cyan;
+        }
     }
 
     const ext = std.fs.path.extension(name);


### PR DESCRIPTION
This PR aims to allow for deeper customization of symlinks.

Previous behavior felt a bit inconsistent.
For example, symlink to a dir would fall back to the file icon/color if not explicitly set in the config:
<img width="1719" height="533" alt="image" src="https://github.com/user-attachments/assets/94779b96-03c3-4506-9ea9-3d84ae95a3dd" />

And by file icon/color, I don't mean the default one, but the empty string in `.by_ext`:
```zig
.by_ext = .{
    .{ .ext = "", .icon = "፠ " },
},
.by_ext = .{
    .{ .ext = "", .color = "bright_cyan" },
},
```

So this is the list of changes I made:

1. Support for inheriting target icon/color.
2. Support for customizing dir symlink independently.
3. Correctly falling back to the symlink icon if one is not explicitly defined in config.
4. Changed default symlink color from `cyan` to `bright_cyan` so it's consistent with other colors.

One small note.
I decided to make `inherit_symlink` and `inherit_dir_symlink` general options, not separate for icon/color.
This made the code slightly cleaner, but I could absolutely change this if you'd like.

I understand if this PR is out of the project scope and you don't want it merged, I can just apply the patch to my fork in that case.
Appreciate your work and time!