### PR TITLE
Sort by index instead of shuffling whole File values

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ Each `<dir>` was a throwaway folder with `n` small text files (`file_0.txt` …)
 
 | Tool | n=50 | n=500 | n=5000 | n=50000 |
 | :--- | :--- | :--- | :--- | :--- |
-| `zl` | `1.2 ms ± 0.4 ms` [U 0.6 / S 0.4] | `1.7 ms ± 0.6 ms` [U 0.9 / S 0.6] | `5.9 ms ± 0.6 ms` [U 3.3 / S 2.0] | `49.9 ms ± 1.4 ms` [U 32.2 / S 16.8] |
-| `eza` | `3.7 ms ± 0.2 ms` [U 2.3 / S 0.9] | `5.6 ms ± 0.8 ms` [U 3.4 / S 1.9] | `21.2 ms ± 0.6 ms` [U 11.6 / S 8.9] | `176 ms ± 4.4 ms` [U 107 / S 66.9] |
-| `lsd` | `3.6 ms ± 0.5 ms` [U 1.6 / S 1.6] | `13.5 ms ± 2.9 ms` [U 2.9 / S 9.9] | `112 ms ± 1.9 ms` [U 13.5 / S 97.2] | `1.293 s ± 0.057 s` [U 0.12 / S 1.16] |
+| `zl` | `0.8 ms ± 0.4 ms` [U 0.6 / S 0.4] | `1.5 ms ± 0.1 ms` [U 0.7 / S 0.5] | `3.5 ms ± 0.1 ms` [U 1.6 / S 1.7] | `32.5 ms ± 0.6 ms` [U 15.5 / S 16.4] |
+| `eza` | `3.1 ms ± 0.3 ms` [U 2.2 / S 0.8] | `4.7 ms ± 0.1 ms` [U 2.9 / S 1.4] | `19.0 ms ± 0.6 ms` [U 10.6 / S 7.7] | `179 ms ± 3.6 ms` [U 107 / S 70.7] |
+| `lsd` | `3.0 ms ± 0.1 ms` [U 1.4 / S 1.4] | `13.0 ms ± 0.6 ms` [U 2.7 / S 9.9] | `114 ms ± 1.3 ms` [U 13.6 / S 100] | `1.289 s ± 0.015 s` [U 0.12 / S 1.16] |
 
-`zl` wins every column here. Gap vs `lsd` blows up on big dirs; vs `eza` it's a steadier ~3×. Still plenty of CPU left on the table at 50k (`zl` user time ~32ms) if we want to push further.
+`zl` wins every column here. Gap vs `lsd` blows up on big dirs; vs `eza` it's a steadier ~5.5×. At 50k, `zl` user time is ~16ms and system time ~16ms.
 
 Older README numbers had `eza` stuck near ~3ms even at 50k — that was a bad run on my side (wrong flags / sloppy setup). Ignore those; this table replaces them.
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zlist,
-    .version = "0.1.13",
+    .version = "0.1.14",
     .dependencies = .{
         .clap = .{
             .url = "git+https://github.com/Hejsil/zig-clap#e91d66b1abba2024cd2e816426f14d233d3dad9a",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.14",
     .dependencies = .{
         .clap = .{
-            .url = "git+https://github.com/Hejsil/zig-clap#e91d66b1abba2024cd2e816426f14d233d3dad9a",
-            .hash = "clap-0.12.0-oBajB2LpAQD1BQpAukHcuwhIUoHWYNy2DzU6lDW2v2N8",
+            .url = "git+https://github.com/Hejsil/zig-clap#05faf3905e8548f5cc269a8836e154065e70128d",
+            .hash = "clap-0.12.0-oBajB4XpAQCF1WRKnD5KOKPsnwwT_NNdAJ7Ww3irYJac",
             .lazy = true,
         },
     },

--- a/src/zlist/files.zig
+++ b/src/zlist/files.zig
@@ -142,7 +142,7 @@ pub const Files = struct {
             loaded_git = true;
         }
 
-        sort(files.items, opt.dir_grouping, opt.sort_type, opt.reverse);
+        try sort(allocator, files.items, opt.dir_grouping, opt.sort_type, opt.reverse);
 
         return .{
             .max_display_len = max_len,
@@ -372,11 +372,15 @@ pub const Files = struct {
     }
 
     const SortCtx = struct {
+        items: []const file.File,
         sort_type: opts.SortType,
         dir_grouping: opts.DirGrouping,
         reverse: bool,
 
-        fn lessThan(ctx: SortCtx, a: file.File, b: file.File) bool {
+        fn lessThan(ctx: SortCtx, ai: u32, bi: u32) bool {
+            const a = &ctx.items[ai];
+            const b = &ctx.items[bi];
+
             if (ctx.dir_grouping != .none) {
                 const a_is_dir = a.is_dir or a.is_symlink_to_dir;
                 const b_is_dir = b.is_dir or b.is_symlink_to_dir;
@@ -384,27 +388,63 @@ pub const Files = struct {
             }
 
             const res = switch (ctx.sort_type) {
-                .length => file.File.nameLenLessThan({}, a, b),
-                .mtime => file.File.mtimeMoreThan({}, a, b),
-                .size => file.File.sizeMoreThan({}, a, b),
-                else => file.File.nameLessThan({}, a, b),
+                .length => a.name.len < b.name.len,
+                .mtime => file.File.mtimeMoreThan({}, a.*, b.*),
+                .size => file.File.sizeMoreThan({}, a.*, b.*),
+                else => std.ascii.orderIgnoreCase(a.name, b.name) == .lt,
             };
 
             return if (ctx.reverse) !res else res;
         }
     };
 
-    fn sort(items: []file.File, dir_grouping: opts.DirGrouping, sort_type: opts.SortType, reverse: bool) void {
+    /// Sort by u32 index so pdq isn't swapping fat File values the whole time.
+    /// Permute once at the end.
+    fn sort(
+        allocator: mem.Allocator,
+        items: []file.File,
+        dir_grouping: opts.DirGrouping,
+        sort_type: opts.SortType,
+        reverse: bool,
+    ) !void {
+        if (items.len <= 1) return;
+
+        const idxs = try allocator.alloc(u32, items.len);
+        defer allocator.free(idxs);
+        for (idxs, 0..) |*idx, i| idx.* = @intCast(i);
+
         mem.sortUnstable(
-            file.File,
-            items,
+            u32,
+            idxs,
             SortCtx{
+                .items = items,
                 .dir_grouping = dir_grouping,
                 .sort_type = sort_type,
                 .reverse = reverse,
             },
             SortCtx.lessThan,
         );
+
+        applyIndexPermutation(items, idxs);
+    }
+
+    /// items[i] becomes the original items[idxs[i]]. `idxs` is overwritten.
+    fn applyIndexPermutation(items: []file.File, idxs: []u32) void {
+        for (idxs, 0..) |*slot, i| {
+            var current = i;
+            var src = slot.*;
+            if (src == i) continue;
+
+            const tmp = items[i];
+            while (src != i) {
+                items[current] = items[src];
+                idxs[current] = @intCast(current);
+                current = src;
+                src = idxs[current];
+            }
+            items[current] = tmp;
+            idxs[current] = @intCast(current);
+        }
     }
 
     /// recursively calculate directory size by summing up sizes of all descendant files.


### PR DESCRIPTION
pdq was swapping the entire File struct on every step. That's a chunky type and we were paying for it on big dirs — a lot of the user time at 50k files was just memcpy.

 Now we sort a u32 index array and permute items once. Same order, way less copying.

Default listing, ReleaseFast, same hyperfine setup as the README:

| | n=5000 | n=50000 |
| :--- | :--- | :--- |
| before | 5.9ms (U 3.3) | 49.9ms (U 32.2) |
| after | 3.5ms (U 1.6) | 32.5ms (U 15.5) |

vs eza on 50k is ~5.5× now (was ~3×). Tiny folders won't notice; this is for the fat-directory default path.