### PR TITLE
Group globbed files like ls

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zlist,
-    .version = "0.1.14",
+    .version = "0.1.15",
     .dependencies = .{
         .clap = .{
             .url = "git+https://github.com/Hejsil/zig-clap#05faf3905e8548f5cc269a8836e154065e70128d",

--- a/src/main.zig
+++ b/src/main.zig
@@ -114,58 +114,75 @@ pub fn main(init: std.process.Init.Minimal) !void {
         return;
     };
 
-    for (cli.paths, 0..) |path, index| {
+    var file_paths = try std.ArrayList([]const u8).initCapacity(allocator, cli.paths.len);
+    var dir_paths = try std.ArrayList([]const u8).initCapacity(allocator, cli.paths.len);
+
+    const cwd = std.Io.Dir.cwd();
+    for (cli.paths) |path| {
+        const opened = cwd.openDir(io, path, .{ .iterate = true }) catch |err| switch (err) {
+            error.NotDir => {
+                try file_paths.append(allocator, path);
+                continue;
+            },
+            error.FileNotFound => {
+                std.debug.print("zl: path not found: {s}\n", .{path});
+                continue;
+            },
+            else => return err,
+        };
+        opened.close(io);
+        try dir_paths.append(allocator, path);
+    }
+
+    const stdout_file = std.Io.File.stdout();
+    var listed_anything = false;
+
+    if (file_paths.items.len > 0) {
+        var opt = cli.opt;
+        opt.path = file_paths.items[0];
+        var files = try zlist.Files.initFromPaths(allocator, io, file_paths.items, opt);
+        defer files.deinit();
+        try printFiles(io, stdout_file, opt, cli.long_view_opt, cli.root_display, cli.pure, cli.color_use, config, &files, null);
+        listed_anything = true;
+    }
+
+    const show_dir_header = file_paths.items.len > 0 or dir_paths.items.len > 1;
+    for (dir_paths.items) |path| {
         var opt = cli.opt;
         opt.path = path;
 
-        // Reuse parsed rendering options for every requested path.
-        runForPath(allocator, io, opt, cli.long_view_opt, cli.root_display, path, cli.pure, cli.color_use, config, cli.paths.len > 1, index) catch |err| switch (err) {
-            error.FileNotFound => std.debug.print("zl: path not found: {s}\n", .{path}),
-            error.NotDir => std.debug.print("zl: not a directory: {s}\n", .{path}),
+        if (show_dir_header) {
+            try printPathHeader(io, stdout_file, path, listed_anything);
+        }
+
+        const dir = cwd.openDir(io, path, .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound => {
+                std.debug.print("zl: path not found: {s}\n", .{path});
+                continue;
+            },
+            error.NotDir => {
+                std.debug.print("zl: not a directory: {s}\n", .{path});
+                continue;
+            },
             else => return err,
         };
+        defer dir.close(io);
+
+        try runForDirectory(allocator, io, stdout_file, opt, cli.long_view_opt, cli.root_display, cli.pure, cli.color_use, config, dir);
+        listed_anything = true;
     }
 }
 
-inline fn runForPath(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    opt: zlist.FilesOptions,
-    long_view_opt: render.LongViewOptions,
-    root_display: render.RootDisplay,
-    path: []const u8,
-    pure: bool,
-    color_use: render.ColorUse,
-    config: cfg.Config,
-    show_header: bool,
-    index: usize,
-) !void {
-    const stdout_file = std.Io.File.stdout();
+fn printPathHeader(io: std.Io, stdout_file: std.Io.File, path: []const u8, blank_line: bool) !void {
+    var header_buf: [512]u8 = undefined;
+    var header_writer = stdout_file.writer(io, &header_buf);
 
-    if (show_header) {
-        var header_buf: [512]u8 = undefined;
-        var header_writer = stdout_file.writer(io, &header_buf);
-
-        if (index > 0) {
-            try header_writer.interface.writeAll("\n");
-        }
-
-        try header_writer.interface.print("{s}:\n", .{path});
-        try header_writer.interface.flush();
+    if (blank_line) {
+        try header_writer.interface.writeAll("\n");
     }
 
-    const cwd = std.Io.Dir.cwd();
-    const dir = cwd.openDir(io, path, .{ .iterate = true }) catch |err| switch (err) {
-        error.NotDir => return runForSingleFile(allocator, io, stdout_file, opt, long_view_opt, root_display, pure, color_use, config, path),
-        error.FileNotFound => {
-            std.debug.print("zl: path not found: {s}\n", .{path});
-            return;
-        },
-        else => return err,
-    };
-    defer dir.close(io);
-
-    return runForDirectory(allocator, io, stdout_file, opt, long_view_opt, root_display, pure, color_use, config, dir);
+    try header_writer.interface.print("{s}:\n", .{path});
+    try header_writer.interface.flush();
 }
 
 inline fn runForDirectory(
@@ -184,24 +201,6 @@ inline fn runForDirectory(
     defer files.deinit();
 
     try printFiles(io, stdout_file, opt, long_view_opt, root_display, pure, color_use, config, &files, dir);
-}
-
-inline fn runForSingleFile(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    stdout_file: std.Io.File,
-    opt: zlist.FilesOptions,
-    long_view_opt: render.LongViewOptions,
-    root_display: render.RootDisplay,
-    pure: bool,
-    color_use: render.ColorUse,
-    config: cfg.Config,
-    path: []const u8,
-) !void {
-    var files = try zlist.Files.initSingle(allocator, io, path, opt);
-    defer files.deinit();
-
-    try printFiles(io, stdout_file, opt, long_view_opt, root_display, pure, color_use, config, &files, null);
 }
 
 fn printFiles(

--- a/src/zlist/files.zig
+++ b/src/zlist/files.zig
@@ -166,24 +166,20 @@ pub const Files = struct {
         path: []const u8,
         opt: opts.FilesOptions,
     ) !Self {
-        const parent_path = std.fs.path.dirname(path) orelse ".";
-        const base_name = std.fs.path.basename(path);
+        return initFromPaths(allocator, io, &.{path}, opt);
+    }
 
-        const cwd = std.Io.Dir.cwd();
-        const parent_dir = try cwd.openDir(io, parent_path, .{});
-        defer parent_dir.close(io);
-
-        const stat = try parent_dir.statFile(io, base_name, .{});
-        const entry: std.Io.Dir.Entry = .{
-            .name = base_name,
-            .kind = stat.kind,
-            .inode = 0,
-        };
-
+    /// List explicit file paths as one collection. Display names keep the given path.
+    pub fn initFromPaths(
+        allocator: mem.Allocator,
+        io: std.Io,
+        paths: []const []const u8,
+        opt: opts.FilesOptions,
+    ) !Self {
         var name_pool = try name_pool_mod.NamePool.init(allocator);
         errdefer name_pool.deinit();
 
-        var files = try std.ArrayList(file.File).initCapacity(allocator, 1);
+        var files = try std.ArrayList(file.File).initCapacity(allocator, paths.len);
         errdefer {
             deinitItems(allocator, files.items);
             files.deinit(allocator);
@@ -210,55 +206,81 @@ pub const Files = struct {
         var git_inventory = std.StringHashMap(git.GitStatus).init(allocator);
         errdefer deinitGitInventory(allocator, &git_inventory);
 
-        if (try file.File.init(
-            allocator,
-            io,
-            &entry,
-            &parent_dir,
-            .{
-                .load_stat = load_stat,
-                .load_symlink_target = opt.show_detail,
-                .resolve_symlink_dir = opt.dir_grouping != .none,
-                .load_owner = opt.show_detail,
-                .show_hidden = opt.show_hidden,
-                .only_dir = opt.only_dir,
-                .only_file = opt.only_file,
-                .keep_dirs_for_match = opt.recursive,
-                .keep_dirs_for_changed_within = opt.recursive,
-                .keep_dirs_for_size = opt.recursive,
-                .exts = opt.exts,
-                .matches = opt.matches,
-                .changed_within = opt.changed_within,
-                .size_range = opt.size_range,
-                .changed_within_now = changed_within_now,
-            },
-            &username_inventory,
-            &groupname_inventory,
-        )) |single_file| {
-            var item = single_file;
-            errdefer if (item.symlink_target) |target| allocator.free(target);
+        const cwd = std.Io.Dir.cwd();
+        const file_opt = opts.FileOptions{
+            .load_stat = load_stat,
+            .load_symlink_target = opt.show_detail,
+            .resolve_symlink_dir = opt.dir_grouping != .none,
+            .load_owner = opt.show_detail,
+            .show_hidden = opt.show_hidden,
+            .only_dir = opt.only_dir,
+            .only_file = opt.only_file,
+            .keep_dirs_for_match = opt.recursive,
+            .keep_dirs_for_changed_within = opt.recursive,
+            .keep_dirs_for_size = opt.recursive,
+            .exts = opt.exts,
+            .matches = opt.matches,
+            .changed_within = opt.changed_within,
+            .size_range = opt.size_range,
+            .changed_within_now = changed_within_now,
+        };
 
-            item.name = try name_pool.store(base_name);
+        for (paths) |path| {
+            const parent_path = std.fs.path.dirname(path) orelse ".";
+            const base_name = std.fs.path.basename(path);
 
-            if (!opt.show_detail and !opt.recursive) {
-                max_len = item.name.len + 2;
-            }
+            const parent_dir = try cwd.openDir(io, parent_path, .{});
+            defer parent_dir.close(io);
 
-            if (opt.report) {
-                if (item.is_dir) {
-                    total_folders = 1;
-                } else {
-                    total_files = 1;
+            const stat = try parent_dir.statFile(io, base_name, .{});
+            const entry: std.Io.Dir.Entry = .{
+                .name = base_name,
+                .kind = stat.kind,
+                .inode = 0,
+            };
+
+            if (try file.File.init(
+                allocator,
+                io,
+                &entry,
+                &parent_dir,
+                file_opt,
+                &username_inventory,
+                &groupname_inventory,
+            )) |single_file| {
+                var item = single_file;
+                errdefer if (item.symlink_target) |target| allocator.free(target);
+
+                item.name = try name_pool.store(path);
+
+                if (!opt.show_detail and !opt.recursive) {
+                    const curr_len = item.name.len + 2;
+                    if (curr_len > max_len) {
+                        max_len = curr_len;
+                    }
                 }
+
+                if (opt.report) {
+                    if (item.is_dir) {
+                        total_folders += 1;
+                    } else {
+                        total_files += 1;
+                    }
+                }
+
+                try files.append(allocator, item);
             }
-
-            try files.append(allocator, item);
         }
 
-        if (opt.show_git and git.isGitRepo(allocator, io, parent_path)) {
-            git_inventory = try git.getFileStatuses(allocator, io, parent_path);
-            loaded_git = true;
+        if (opt.show_git and paths.len > 0) {
+            const git_path = std.fs.path.dirname(paths[0]) orelse ".";
+            if (git.isGitRepo(allocator, io, git_path)) {
+                git_inventory = try git.getFileStatuses(allocator, io, git_path);
+                loaded_git = true;
+            }
         }
+
+        try sort(allocator, files.items, opt.dir_grouping, opt.sort_type, opt.reverse);
 
         return .{
             .max_display_len = max_len,
@@ -342,7 +364,7 @@ pub const Files = struct {
     /// Return the git status for a file name, if one was loaded.
     pub inline fn gitStatus(self: Self, name: []const u8) ?git.GitStatus {
         if (!self.loaded_git) return null;
-        return self.git_inventory.get(name);
+        return self.git_inventory.get(std.fs.path.basename(name));
     }
 
     /// Return the options used to create this listing.
@@ -535,4 +557,18 @@ test "without recursive directory size directory keeps stat size" {
     }
 
     try testing.expect(found_dir);
+}
+
+test "initFromPaths keeps the given path as the name" {
+    const io = testing.io;
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    const paths = [_][]const u8{ "src/main.zig", "src/zlist.zig" };
+    var files = try Files.initFromPaths(arena.allocator(), io, &paths, .{});
+    defer files.deinit();
+
+    try testing.expectEqual(@as(usize, 2), files.entries().len);
+    try testing.expectEqualStrings("src/main.zig", files.entries()[0].name);
+    try testing.expectEqualStrings("src/zlist.zig", files.entries()[1].name);
 }


### PR DESCRIPTION
`zl src/*` used to treat every match as its own listing, so each file got a src/foo.zig: header. Directories were fine; files looked pretty off next to `ls`.

File operands now render as one group. Directory headers only show up when there's at least one file in the mix, or more than one directory:

```bash
src/cfg.zig  src/main.zig  src/render.zig  ...

src/zlist:
file.zig  git.zig  ...
```

Same deal for explicit multi-file args (`zl a.zig b.zig`). Single-dir calls like `zl src` are unchanged.

Closed: #96 